### PR TITLE
 Changed color table to use existing padding

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -59,7 +59,7 @@ class TestFileGif(PillowTestCase):
             return len(test_file.getvalue())
 
         self.assertEqual(test_grayscale(0), 800)
-        self.assertEqual(test_grayscale(1), 38)
+        self.assertEqual(test_grayscale(1), 44)
         self.assertEqual(test_bilevel(0), 800)
         self.assertEqual(test_bilevel(1), 800)
 

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -444,8 +444,7 @@ def _write_multiple_frames(im, fp, palette):
             if im_frames:
                 # delta frame
                 previous = im_frames[-1]
-                if "disposal" in encoderinfo \
-                   and encoderinfo["disposal"] == 2:
+                if encoderinfo.get("disposal") == 2:
                     base_image = background
                 else:
                     base_image = previous["im"]
@@ -457,8 +456,7 @@ def _write_multiple_frames(im, fp, palette):
                     delta = ImageChops.subtract_modulo(
                         im_frame.convert('RGB'), base_image.convert('RGB'))
                 bbox = delta.getbbox()
-                if not bbox and not ("disposal" in encoderinfo
-                   and encoderinfo["disposal"] == 2):
+                if not bbox and encoderinfo.get("disposal") != 2:
                     # This frame is identical to the previous frame
                     if duration:
                         previous['encoderinfo']['duration'] += \
@@ -476,8 +474,7 @@ def _write_multiple_frames(im, fp, palette):
     if len(im_frames) > 1:
         for frame_data in im_frames:
             im_frame = frame_data['im']
-            if("disposal" in frame_data["encoderinfo"]
-               and frame_data["encoderinfo"]["disposal"] == 2):
+            if frame_data["encoderinfo"].get("disposal") == 2:
                 frame_data['encoderinfo']['include_color_table'] = True
             if not frame_data['bbox']:
                 # global header

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -585,21 +585,16 @@ def _write_local_header(fp, im, offset, flags):
     include_color_table = im.encoderinfo.get('include_color_table')
     if include_color_table:
         palette_bytes = _get_palette_bytes(im)
-        # If needed, expand palette to minimum size
-        while(len(palette_bytes) < 9):
-            palette_bytes = palette_bytes*2
         color_table_size = _get_color_table_size(palette_bytes)
-        if color_table_size:
-            flags = flags | 128               # local color table flag
-            flags = flags | color_table_size
-
+        flags = flags | 128               # local color table flag
+        flags = flags | color_table_size
     fp.write(b"," +
              o16(offset[0]) +             # offset
              o16(offset[1]) +
              o16(im.size[0]) +            # size
              o16(im.size[1]) +
              o8(flags))                   # flags
-    if include_color_table and color_table_size:
+    if include_color_table:
         fp.write(_get_header_palette(palette_bytes))
     fp.write(o8(8))                       # bits
 
@@ -692,8 +687,8 @@ def _get_color_table_size(palette_bytes):
     # calculate the palette size for the header
     import math
     color_table_size = int(math.ceil(math.log(len(palette_bytes)//3, 2)))-1
-    if color_table_size < 0:
-        color_table_size = 0
+    if color_table_size < 1:
+        color_table_size = 1
     return color_table_size
 
 


### PR DESCRIPTION
This moves the minimum color table size into `_get_color_table_size`, meaning that the padding in `_get_header_palette` is used, rather than adding in new code to pad the palette.

Feel free to lend your thoughts.